### PR TITLE
chore(ci): Update setup-gradle action to v5

### DIFF
--- a/.github/workflows/deploy_debug_to_firebase.yml
+++ b/.github/workflows/deploy_debug_to_firebase.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v5
         with:
           gradle-version: '8.13'
 


### PR DESCRIPTION
Update the `gradle/gradle-build-action` to `gradle/actions/setup-gradle@v5` in the Firebase deployment workflow.