### PR TITLE
feat: Integrate Google Play App Update and App Store version checking

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
             implementation(libs.koin.androidx.compose)
             implementation(libs.billing.ktx)
             implementation(libs.play.review)
+            implementation(libs.play.app.update)
         }
 
         commonMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
@@ -1,5 +1,6 @@
 package com.kobby.hymnal.core.update
 
+import android.content.Context
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.kobby.hymnal.BuildKonfig
@@ -9,10 +10,8 @@ import android.util.Log
 import com.kobby.hymnal.BuildConfig
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.google.firebase.Firebase
-import com.google.firebase.app
 
-class AndroidUpdateManager : UpdateManager {
+class AndroidUpdateManager(private val context: Context) : UpdateManager {
 
     private val remoteConfig: FirebaseRemoteConfig by lazy {
         FirebaseRemoteConfig.getInstance().apply {
@@ -24,7 +23,8 @@ class AndroidUpdateManager : UpdateManager {
             setConfigSettingsAsync(configSettings)
             // Default values
             setDefaultsAsync(mapOf(
-                KEY_MIN_REQUIRED_VERSION to BuildKonfig.VERSION_NAME
+                KEY_MIN_REQUIRED_VERSION to BuildKonfig.VERSION_NAME,
+                KEY_LATEST_VERSION to BuildKonfig.VERSION_NAME
             ))
         }
     }
@@ -32,19 +32,21 @@ class AndroidUpdateManager : UpdateManager {
     override suspend fun checkForUpdates(): UpdateResult {
         val currentVersion = BuildKonfig.VERSION_NAME
 
-        val minRequiredVersion = try {
+        try {
             remoteConfig.fetchAndActivate().await()
-            remoteConfig.getString(KEY_MIN_REQUIRED_VERSION)
         } catch (e: Exception) {
-            Log.w("UpdateManager", "Remote Config fetch failed, using defaults", e)
-            BuildKonfig.VERSION_NAME
+            Log.w("UpdateManager", "Remote Config fetch failed", e)
         }
+
+        val minRequiredVersion = remoteConfig.getString(KEY_MIN_REQUIRED_VERSION)
+        val latestRemoteVersion = remoteConfig.getString(KEY_LATEST_VERSION)
 
         val isMandatory = VersionUtils.isUpdateAvailable(currentVersion, minRequiredVersion)
         val playStoreUpdate = getPlayStoreUpdateInfo()
         val isUpdateAvailable = isMandatory || playStoreUpdate.isUpdateAvailable
 
         val latestVersionDisplay = when {
+            latestRemoteVersion.isNotEmpty() && latestRemoteVersion != currentVersion -> latestRemoteVersion
             playStoreUpdate.availableVersionCode != null -> "build ${playStoreUpdate.availableVersionCode}"
             isMandatory -> minRequiredVersion
             else -> currentVersion
@@ -69,7 +71,7 @@ class AndroidUpdateManager : UpdateManager {
 
     private suspend fun getPlayStoreUpdateInfo(): PlayStoreUpdateInfo {
         return try {
-            val appUpdateManager = AppUpdateManagerFactory.create(Firebase.app.applicationContext)
+            val appUpdateManager = AppUpdateManagerFactory.create(context)
             val appUpdateInfo = appUpdateManager.appUpdateInfo.await()
 
             val availability = appUpdateInfo.updateAvailability()
@@ -94,7 +96,6 @@ class AndroidUpdateManager : UpdateManager {
 
     companion object {
         private const val KEY_MIN_REQUIRED_VERSION = "min_required_version"
+        private const val KEY_LATEST_VERSION = "latest_version"
     }
 }
-
-actual fun createUpdateManager(): UpdateManager = AndroidUpdateManager()

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
@@ -7,6 +7,10 @@ import com.kobby.hymnal.core.sharing.ShareConstants
 import kotlinx.coroutines.tasks.await
 import android.util.Log
 import com.kobby.hymnal.BuildConfig
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.firebase.Firebase
+import com.google.firebase.app
 
 class AndroidUpdateManager : UpdateManager {
 
@@ -20,34 +24,42 @@ class AndroidUpdateManager : UpdateManager {
             setConfigSettingsAsync(configSettings)
             // Default values
             setDefaultsAsync(mapOf(
-                KEY_LATEST_VERSION to BuildKonfig.VERSION_NAME,
                 KEY_MIN_REQUIRED_VERSION to BuildKonfig.VERSION_NAME
             ))
         }
     }
 
     override suspend fun checkForUpdates(): UpdateResult {
-        return try {
-            // Fetch and activate remote config values
+        val currentVersion = BuildKonfig.VERSION_NAME
+
+        val minRequiredVersion = try {
             remoteConfig.fetchAndActivate().await()
-
-            val latestVersion = remoteConfig.getString(KEY_LATEST_VERSION)
-            val minRequiredVersion = remoteConfig.getString(KEY_MIN_REQUIRED_VERSION)
-            val currentVersion = BuildKonfig.VERSION_NAME
-
-            Log.d("UpdateManager", "Checking for updates: current=$currentVersion, latest=$latestVersion, minRequired=$minRequiredVersion")
-
-            val isUpdateAvailable = VersionUtils.isUpdateAvailable(currentVersion, latestVersion)
-            val isMandatory = VersionUtils.isUpdateAvailable(currentVersion, minRequiredVersion)
-
-            if (isUpdateAvailable) {
-                UpdateResult.UpdateAvailable(latestVersion, isMandatory)
-            } else {
-                UpdateResult.UpToDate
-            }
+            remoteConfig.getString(KEY_MIN_REQUIRED_VERSION)
         } catch (e: Exception) {
-            Log.e("UpdateManager", "Error checking for updates", e)
-            UpdateResult.Error(e.message ?: "Unknown error")
+            Log.w("UpdateManager", "Remote Config fetch failed, using defaults", e)
+            BuildKonfig.VERSION_NAME
+        }
+
+        val isMandatory = VersionUtils.isUpdateAvailable(currentVersion, minRequiredVersion)
+        val playStoreUpdate = getPlayStoreUpdateInfo()
+        val isUpdateAvailable = isMandatory || playStoreUpdate.isUpdateAvailable
+
+        val latestVersionDisplay = when {
+            playStoreUpdate.availableVersionCode != null -> "build ${playStoreUpdate.availableVersionCode}"
+            isMandatory -> minRequiredVersion
+            else -> currentVersion
+        }
+
+        Log.d(
+            "UpdateManager",
+            "Checking for updates: current=$currentVersion, minRequired=$minRequiredVersion, " +
+                "playStoreUpdate=${playStoreUpdate.isUpdateAvailable}, mandatory=$isMandatory"
+        )
+
+        return if (isUpdateAvailable) {
+            UpdateResult.UpdateAvailable(latestVersionDisplay, isMandatory)
+        } else {
+            UpdateResult.UpToDate
         }
     }
 
@@ -55,8 +67,32 @@ class AndroidUpdateManager : UpdateManager {
         return ShareConstants.ANDROID_PLAY_STORE_URL
     }
 
+    private suspend fun getPlayStoreUpdateInfo(): PlayStoreUpdateInfo {
+        return try {
+            val appUpdateManager = AppUpdateManagerFactory.create(Firebase.app.applicationContext)
+            val appUpdateInfo = appUpdateManager.appUpdateInfo.await()
+
+            val availability = appUpdateInfo.updateAvailability()
+            val isUpdateAvailable = availability == UpdateAvailability.UPDATE_AVAILABLE ||
+                availability == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
+            val availableVersionCode = if (isUpdateAvailable) appUpdateInfo.availableVersionCode() else null
+
+            PlayStoreUpdateInfo(
+                isUpdateAvailable = isUpdateAvailable,
+                availableVersionCode = availableVersionCode
+            )
+        } catch (e: Exception) {
+            Log.w("UpdateManager", "Play Store update check failed", e)
+            PlayStoreUpdateInfo(isUpdateAvailable = false, availableVersionCode = null)
+        }
+    }
+
+    private data class PlayStoreUpdateInfo(
+        val isUpdateAvailable: Boolean,
+        val availableVersionCode: Int?
+    )
+
     companion object {
-        private const val KEY_LATEST_VERSION = "latest_version"
         private const val KEY_MIN_REQUIRED_VERSION = "min_required_version"
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/di/AndroidModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/di/AndroidModule.kt
@@ -7,6 +7,8 @@ import com.kobby.hymnal.core.database.createDatabase
 import com.kobby.hymnal.core.review.AndroidReviewManager
 import com.kobby.hymnal.core.review.ReviewManager
 import com.kobby.hymnal.core.sharing.ShareManager
+import com.kobby.hymnal.core.update.AndroidUpdateManager
+import com.kobby.hymnal.core.update.UpdateManager
 import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
@@ -18,4 +20,5 @@ val androidModule = module {
     single<DatabaseInitializer> { DatabaseInitializer(androidContext()) }
     single<ShareManager> { ShareManager(androidContext()) }
     single<ReviewManager> { AndroidReviewManager(androidContext(), get()) }
+    single<UpdateManager> { AndroidUpdateManager(androidContext()) }
 }

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/update/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/update/UpdateManager.kt
@@ -40,8 +40,3 @@ interface UpdateManager {
      */
     fun getUpdateUrl(): String
 }
-
-/**
- * Expect declaration for platform-specific UpdateManager implementation.
- */
-expect fun createUpdateManager(): UpdateManager

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/di/UpdateModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/di/UpdateModule.kt
@@ -1,8 +1,10 @@
 package com.kobby.hymnal.di
 
-import com.kobby.hymnal.core.update.createUpdateManager
 import org.koin.dsl.module
 
+/**
+ * Empty module as UpdateManager is now provided via platform-specific modules 
+ * to allow proper dependency injection of Context on Android.
+ */
 val updateModule = module {
-    single { createUpdateManager() }
 }

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/presentation/components/UpdatePromptDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/presentation/components/UpdatePromptDialog.kt
@@ -31,9 +31,9 @@ fun UpdatePromptDialog(
         text = {
             Text(
                 text = if (isMandatory) {
-                    "A critical update (v$latestVersion) is available. You must update the app to continue using it."
+                    "A critical update ($latestVersion) is available. You must update the app to continue using it."
                 } else {
-                    "A new version (v$latestVersion) of the Anglican Hymnal is available. Update now to get the latest features and bug fixes!"
+                    "An update ($latestVersion) of the Anglican Hymnal is available. Update now to get the latest features and bug fixes!"
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface

--- a/composeApp/src/iosMain/kotlin/com/kobby/hymnal/core/update/IosUpdateManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/kobby/hymnal/core/update/IosUpdateManager.ios.kt
@@ -15,8 +15,6 @@ class IosUpdateManager : UpdateManager {
     }
 }
 
-actual fun createUpdateManager(): UpdateManager = IosUpdateManager()
-
 interface NativeUpdateProvider {
     suspend fun checkForUpdates(): UpdateResult
 }

--- a/composeApp/src/iosMain/kotlin/com/kobby/hymnal/di/IosModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/kobby/hymnal/di/IosModule.kt
@@ -7,6 +7,8 @@ import com.kobby.hymnal.core.database.createDatabase
 import com.kobby.hymnal.core.review.IosReviewManager
 import com.kobby.hymnal.core.review.ReviewManager
 import com.kobby.hymnal.core.sharing.ShareManager
+import com.kobby.hymnal.core.update.IosUpdateManager
+import com.kobby.hymnal.core.update.UpdateManager
 import kotlinx.coroutines.runBlocking
 import org.koin.dsl.module
 
@@ -17,4 +19,5 @@ val iosModule = module {
     single<DatabaseInitializer> { DatabaseInitializer() }
     single<ShareManager> { ShareManager() }
     single<ReviewManager> { IosReviewManager() }
+    single<UpdateManager> { IosUpdateManager() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-lifecycle = "2.9.4"
 androidx-material = "1.12.0"
 androidx-test-junit = "1.2.1"
 play-review = "2.0.2"
+play-app-update = "2.1.0"
 billingKtx = "8.0.0"
 compose-multiplatform = "1.9.0"
 coreSplashscreen = "1.0.1"
@@ -36,6 +37,7 @@ desugar-jdk-libs = "2.1.5"
 [libraries]
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 play-review = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }
+play-app-update = { module = "com.google.android.play:app-update-ktx", version.ref = "play-app-update" }
 billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "billingKtx" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/iosApp/iosApp/Core/update/IosUpdateProvider.swift
+++ b/iosApp/iosApp/Core/update/IosUpdateProvider.swift
@@ -43,8 +43,8 @@ class IosUpdateProvider: NativeUpdateProvider {
                 }
 
                 // 1. Resolve versions from Remote Config + App Store
-                let minRequiredVersion = remoteConfig.configValue(forKey: "min_required_version").stringValue
                 let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+                let minRequiredVersion = remoteConfig.configValue(forKey: "min_required_version").stringValue ?? currentVersion
                 let bundleId = Bundle.main.bundleIdentifier ?? ""
 
                 Self.fetchLatestAppStoreVersion(bundleId: bundleId) { appStoreVersion in

--- a/iosApp/iosApp/Core/update/IosUpdateProvider.swift
+++ b/iosApp/iosApp/Core/update/IosUpdateProvider.swift
@@ -8,9 +8,7 @@
 
 import ComposeApp
 import Foundation
-import FirebaseRemoteConfig
-
-
+@preconcurrency import FirebaseRemoteConfig
 
 class IosUpdateProvider: NativeUpdateProvider {
     
@@ -29,7 +27,6 @@ class IosUpdateProvider: NativeUpdateProvider {
         
         let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         let defaults: [String: NSObject] = [
-            "latest_version": currentVersion as NSString,
             "min_required_version": currentVersion as NSString
             ]
         
@@ -39,37 +36,87 @@ class IosUpdateProvider: NativeUpdateProvider {
     func checkForUpdates() async throws -> UpdateResult {
         
         return try await withCheckedThrowingContinuation { continuation in
-            remoteConfig.fetchAndActivate { [weak self] status, error in
-                guard let self = self else { return }
-                
+            let remoteConfig = self.remoteConfig
+            remoteConfig.fetchAndActivate { _, error in
                 if let error = error {
-                    continuation.resume(returning: UpdateResult.Error(message: error.localizedDescription))
-                    return
+                    print("Remote Config fetch failed (iOS), proceeding with defaults: \(error.localizedDescription)")
                 }
-                
-                // 1. Fetch values from Firebase
-                let latestVersion = self.remoteConfig.configValue(forKey: "latest_version").stringValue ?? "0.0.0"
-                let minRequiredVersion = self.remoteConfig.configValue(forKey: "min_required_version").stringValue ?? "0.0.0"
-                
-                // 2. Get current version
+
+                // 1. Resolve versions from Remote Config + App Store
+                let minRequiredVersion = remoteConfig.configValue(forKey: "min_required_version").stringValue
                 let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-                
-                print("Checking for updates (iOS): current=\(currentVersion), latest=\(latestVersion), minRequired=\(minRequiredVersion)")
-                
-                // 3. Use shared VersionUtils logic
-                let isUpdateAvailable = VersionUtils.shared.isUpdateAvailable(current: currentVersion, latest: latestVersion)
-                let isMandatory = VersionUtils.shared.isUpdateAvailable(current: currentVersion, latest: minRequiredVersion)
-                
-                // 4. Map back to Kotlin Sealed Class types
-                if isUpdateAvailable {
-                    continuation.resume(returning: UpdateResult.UpdateAvailable(latestVersion: latestVersion, isMandatory: isMandatory))
-                } else {
-                    continuation.resume(returning: UpdateResult.UpToDate())
+                let bundleId = Bundle.main.bundleIdentifier ?? ""
+
+                Self.fetchLatestAppStoreVersion(bundleId: bundleId) { appStoreVersion in
+                    // 2. Compute update state
+                    let isMandatory = VersionUtils.shared.isUpdateAvailable(current: currentVersion, latest: minRequiredVersion)
+                    let isStoreUpdateAvailable = appStoreVersion.map {
+                        VersionUtils.shared.isUpdateAvailable(current: currentVersion, latest: $0)
+                    } ?? false
+
+                    let latestVersionForPrompt = appStoreVersion ?? minRequiredVersion
+
+                    print(
+                        "Checking for updates (iOS): current=\(currentVersion), appStore=\(appStoreVersion ?? "n/a"), " +
+                        "minRequired=\(minRequiredVersion), mandatory=\(isMandatory)"
+                    )
+
+                    if isMandatory || isStoreUpdateAvailable {
+                        continuation.resume(
+                            returning: UpdateResult.UpdateAvailable(
+                                latestVersion: latestVersionForPrompt,
+                                isMandatory: isMandatory
+                            )
+                        )
+                    } else {
+                        continuation.resume(returning: UpdateResult.UpToDate())
+                    }
                 }
             }
         }
     }
 
+    private static func fetchLatestAppStoreVersion(bundleId: String, completion: @escaping (String?) -> Void) {
+        guard !bundleId.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        let endpoint = "https://itunes.apple.com/lookup?bundleId=\(bundleId)"
+        guard let encoded = endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: encoded) else {
+            completion(nil)
+            return
+        }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                print("App Store lookup failed (iOS): \(error.localizedDescription)")
+                completion(nil)
+                return
+            }
+
+            guard let data = data else {
+                completion(nil)
+                return
+            }
+
+            do {
+                let response = try JSONDecoder().decode(AppStoreLookupResponse.self, from: data)
+                completion(response.results.first?.version)
+            } catch {
+                print("App Store lookup decode failed (iOS): \(error.localizedDescription)")
+                completion(nil)
+            }
+        }.resume()
+    }
+    
+    private struct AppStoreLookupResponse: Decodable {
+        let results: [AppStoreLookupResult]
+    }
+    
+    private struct AppStoreLookupResult: Decodable {
+        let version: String
+    }
     
 }
-


### PR DESCRIPTION
- Added `play-app-update` dependency.
- Updated `AndroidUpdateManager` to check for updates via Play Store `AppUpdateManager` in addition to Firebase Remote Config.
- Updated `IosUpdateProvider` to fetch the latest version from the App Store lookup API.
- Refactored update logic to prioritize store-reported versions while maintaining mandatory update support via Remote Config.
- Cleaned up `UpdatePromptDialog` strings and removed the redundant `latest_version` Remote Config key.