### PR TITLE
feat: adjust donation prompt thresholds and caps

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
@@ -34,7 +34,7 @@ class PurchaseStorage(private val settings: Settings) {
         private const val KEY_NEXT_PROMPT_THRESHOLD = "next_prompt_threshold"
         private const val KEY_LAST_RESET_TIMESTAMP = "last_reset_timestamp"
 
-        const val PROMPT_CAP_THRESHOLD = 150
+        const val PROMPT_CAP_THRESHOLD = 50
     }
 
     /**
@@ -205,16 +205,16 @@ class PurchaseStorage(private val settings: Settings) {
     }
 
     /**
-     * Calculate the next prompt threshold based on prompt count.
-     * Milestones: 10, 30 (10+20), 60 (30+30), 100 (60+40), 150 (100+50)
+     * Get the next prompt threshold based on prompt count.
      */
-    fun calculateNextThreshold(): Int {
+    fun getNextThreshold(): Int {
         return when (donationPromptCount) {
-            1 -> 30
-            2 -> 60
-            3 -> 100
-            4 -> 150
-            else -> 200 // Cap handled in UsageTrackingManager
+            1 -> 10
+            2 -> 20
+            3 -> 30
+            4 -> 38
+            5 -> 45
+            else -> 50 // Cap handled in UsageTrackingManager
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
@@ -34,7 +34,7 @@ class PurchaseStorage(private val settings: Settings) {
         private const val KEY_NEXT_PROMPT_THRESHOLD = "next_prompt_threshold"
         private const val KEY_LAST_RESET_TIMESTAMP = "last_reset_timestamp"
 
-        const val PROMPT_CAP_THRESHOLD = 50
+        const val PROMPT_CAP_THRESHOLD = 60
     }
 
     /**
@@ -209,12 +209,11 @@ class PurchaseStorage(private val settings: Settings) {
      */
     fun getNextThreshold(): Int {
         return when (donationPromptCount) {
-            1 -> 10
-            2 -> 20
-            3 -> 30
-            4 -> 38
-            5 -> 45
-            else -> 50 // Cap handled in UsageTrackingManager
+            1 -> 20
+            2 -> 30
+            3 -> 40
+            4 -> 50
+            else -> PROMPT_CAP_THRESHOLD // Cap handled in UsageTrackingManager
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/UsageTrackingManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/UsageTrackingManager.kt
@@ -106,7 +106,7 @@ class UsageTrackingManager(private val storage: PurchaseStorage) {
     /**
      * Check if donation prompt should be shown based on milestone-based logic.
      * Updated behavior: supporters NEVER see the paywall again (no yearly reminders).
-     * Non-supporters:  50 hymns read (capped).
+     * Non-supporters: 10, 20, 30, 38, 45, 50 hymns read (capped).
      */
     fun shouldShowDonationPrompt(isSupporter: Boolean): Boolean {
         // Supporters should not be shown donation prompts anymore
@@ -114,7 +114,7 @@ class UsageTrackingManager(private val storage: PurchaseStorage) {
             return false
         }
 
-
+        // For non-supporters, use milestones (10, 20, 30, 38, 45, 50) with a hard cap at 50
         val hymnsRead = storage.hymnsReadCount
         if (hymnsRead > PurchaseStorage.PROMPT_CAP_THRESHOLD) {
             return false

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/UsageTrackingManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/UsageTrackingManager.kt
@@ -9,7 +9,6 @@ import kotlinx.datetime.Clock
  * Tracks app usage to determine when to show donation prompts.
  * Uses a milestone-based backoff to show prompts at regular intervals.
  *
- * Non-supporters: 10, 30, 60, 100, 150 (capped) hymns
  */
 class UsageTrackingManager(private val storage: PurchaseStorage) {
 
@@ -107,7 +106,7 @@ class UsageTrackingManager(private val storage: PurchaseStorage) {
     /**
      * Check if donation prompt should be shown based on milestone-based logic.
      * Updated behavior: supporters NEVER see the paywall again (no yearly reminders).
-     * Non-supporters: 10, 30, 60, 100, 150 hymns read (capped).
+     * Non-supporters:  50 hymns read (capped).
      */
     fun shouldShowDonationPrompt(isSupporter: Boolean): Boolean {
         // Supporters should not be shown donation prompts anymore
@@ -115,7 +114,7 @@ class UsageTrackingManager(private val storage: PurchaseStorage) {
             return false
         }
 
-        // For non-supporters, use milestones (10, 30, 60, 100, 150) with a hard cap at 150
+
         val hymnsRead = storage.hymnsReadCount
         if (hymnsRead > PurchaseStorage.PROMPT_CAP_THRESHOLD) {
             return false
@@ -170,7 +169,7 @@ class UsageTrackingManager(private val storage: PurchaseStorage) {
         storage.donationPromptCount += 1
 
         // Calculate and store next threshold based on new prompt count (no supporter branch)
-        val nextThreshold = storage.calculateNextThreshold()
+        val nextThreshold = storage.getNextThreshold()
         storage.nextPromptThreshold = nextThreshold
     }
 


### PR DESCRIPTION
- Reduce `PROMPT_CAP_THRESHOLD` from 150 to 50
- Update `calculateNextThreshold` to `getNextThreshold` with new milestone intervals (10, 20, 30, 38, 45, 50)
- Update `UsageTrackingManager` to reflect the new capping logic for non-supporters