### PR TITLE
Fix billing flow NPE and improve testability

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -80,8 +80,7 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.multiplatform.settings.test)
-            // Removed sqldelight.jvm to fix iOS test compilation
-            // Add platform-specific test drivers if needed
+            implementation(libs.sqldelight.jvm)
         }
 
         iosMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/iap/BillingHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/iap/BillingHelper.kt
@@ -20,6 +20,18 @@ class BillingHelper(private val context: Context) {
     val SUPPORT_GENEROUS = "support_generous"
     val TAG = BillingHelper::class.simpleName
     var purchaseCallback:((isSuccess:Boolean)->Unit)? = null
+    private val callbackLock = Any()
+    private var purchasingProductId: String? = null
+
+    private fun invokePurchaseCallback(isSuccess: Boolean) {
+        val callback = synchronized(callbackLock) {
+            purchasingProductId = null
+            val cb = purchaseCallback
+            purchaseCallback = null
+            cb
+        }
+        callback?.invoke(isSuccess)
+    }
 
 
     var params: PendingPurchasesParams = PendingPurchasesParams.newBuilder()
@@ -43,18 +55,15 @@ class BillingHelper(private val context: Context) {
                     }
                     BillingClient.BillingResponseCode.USER_CANCELED -> {
                         Log.d(TAG, "User canceled the purchase")
-                        purchaseCallback?.invoke(false)
-                        purchaseCallback = null
+                        invokePurchaseCallback(false)
                     }
                     BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> {
                         Log.d(TAG, "Item already owned")
-                        purchaseCallback?.invoke(true)
-                        purchaseCallback = null
+                        invokePurchaseCallback(true)
                     }
                     else -> {
                         Log.e(TAG, "Purchase failed: ${billingResult.responseCode} - ${billingResult.debugMessage}")
-                        purchaseCallback?.invoke(false)
-                        purchaseCallback = null
+                        invokePurchaseCallback(false)
                     }
                 }
             }
@@ -181,15 +190,25 @@ class BillingHelper(private val context: Context) {
     }
 
     fun purchaseProduct(productId: String, productType: String, activity: Activity, callback: (Boolean) -> Unit) {
+        synchronized(callbackLock) {
+            if (purchaseCallback != null || purchasingProductId != null) {
+                Log.e(TAG, "A purchase is already in progress")
+                callback(false)
+                return
+            }
+            purchaseCallback = callback
+            purchasingProductId = productId
+        }
+
         // First, ensure we're connected to the Play Store
         connectPlayStore { isConnected ->
             if (!isConnected) {
                 Log.e(TAG, "Failed to connect to Play Store")
-                callback(false)
+                invokePurchaseCallback(false)
                 return@connectPlayStore
             }
 
-            val params = QueryProductDetailsParams.newBuilder()
+            val queryParams = QueryProductDetailsParams.newBuilder()
                 .setProductList(
                     listOf(
                         QueryProductDetailsParams.Product.newBuilder()
@@ -200,9 +219,10 @@ class BillingHelper(private val context: Context) {
                 )
                 .build()
 
-            billingClient.queryProductDetailsAsync(params) { billingResult, queryProductDetailsResult ->
-                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && queryProductDetailsResult.productDetailsList.isNotEmpty()) {
-                    val productDetails = queryProductDetailsResult.productDetailsList.first()
+            billingClient.queryProductDetailsAsync(queryParams) { billingResult, queryProductDetailsResult ->
+                val detailsList = queryProductDetailsResult?.productDetailsList
+                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && !detailsList.isNullOrEmpty()) {
+                    val productDetails = detailsList.first()
 
                     val billingParamsBuilder = BillingFlowParams.newBuilder()
                         .setProductDetailsParamsList(
@@ -214,7 +234,7 @@ class BillingHelper(private val context: Context) {
                                             val offerToken = productDetails.subscriptionOfferDetails?.first()?.offerToken
                                             if (offerToken == null) {
                                                 Log.e(TAG, "No offer token found for subscription product")
-                                                callback(false)
+                                                invokePurchaseCallback(false)
                                                 return@queryProductDetailsAsync
                                             }
                                             setOfferToken(offerToken)
@@ -224,82 +244,91 @@ class BillingHelper(private val context: Context) {
                             )
                         )
                         .build()
-
-                    purchaseCallback = callback
                     
                     var launchSuccessful = false
                     if (billingClient.isReady) {
-                        val launchResult = billingClient.launchBillingFlow(activity, billingParamsBuilder)
-                        if (launchResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                            launchSuccessful = true
-                        } else {
-                            Log.e(TAG, "Failed to launch billing flow: ${launchResult.responseCode} - ${launchResult.debugMessage}")
+                        try {
+                            val launchResult = billingClient.launchBillingFlow(activity, billingParamsBuilder)
+                            if (launchResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                                launchSuccessful = true
+                            } else {
+                                Log.e(TAG, "Failed to launch billing flow: ${launchResult.responseCode} - ${launchResult.debugMessage}")
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Exception launching billing flow", e)
                         }
                     } else {
                         Log.e(TAG, "BillingClient is not ready right before launching flow")
                     }
 
                     if (!launchSuccessful) {
-                        purchaseCallback = null
-                        callback(false)
+                        invokePurchaseCallback(false)
                     }
                 } else {
                     Log.e(TAG, "Failed to query product details: ${billingResult.responseCode} - ${billingResult.debugMessage}")
-                    callback(false)
+                    invokePurchaseCallback(false)
                 }
             }
         }
     }
 
     private fun handlePurchase(purchases: List<Purchase>) {
-        for (purchase in purchases) {
-            when (purchase.purchaseState) {
-                Purchase.PurchaseState.PURCHASED -> {
-                    // Grant support benefits for one-time purchases
-                    Log.d(TAG, "Purchase is active: ${purchase.products}")
+        // Find if there is a purchase matching the purchasingProductId
+        val targetPurchase = purchases.find { purchase ->
+            purchasingProductId?.let { purchase.products.contains(it) } ?: true
+        }
 
-                    if (!purchase.isAcknowledged) {
-                        val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
-                            .setPurchaseToken(purchase.purchaseToken)
-                            .build()
-                        
-                        var shouldInvokeCallbackNow = true
-                        if (billingClient.isReady) {
-                            billingClient.acknowledgePurchase(acknowledgePurchaseParams) { billingResult ->
-                                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                                    Log.d(TAG, "Purchase acknowledged successfully: ${purchase.products}")
-                                } else {
-                                    Log.e(TAG, "Failed to acknowledge purchase: ${billingResult.responseCode} - ${billingResult.debugMessage}")
-                                }
-                                // Still grant benefit if state is PURCHASED, even if acknowledgment failed
-                                purchaseCallback?.invoke(true)
-                                purchaseCallback = null
+        if (targetPurchase != null) {
+            processSinglePurchase(targetPurchase)
+        } else if (purchases.isNotEmpty()) {
+            // Fallback: process the first purchase if no match is found
+            processSinglePurchase(purchases.first())
+        }
+    }
+
+    private fun processSinglePurchase(purchase: Purchase) {
+        when (purchase.purchaseState) {
+            Purchase.PurchaseState.PURCHASED -> {
+                // Grant support benefits for one-time purchases
+                Log.d(TAG, "Purchase is active: ${purchase.products}")
+
+                if (!purchase.isAcknowledged) {
+                    val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
+                        .setPurchaseToken(purchase.purchaseToken)
+                        .build()
+                    
+                    var shouldInvokeCallbackNow = true
+                    if (billingClient.isReady) {
+                        billingClient.acknowledgePurchase(acknowledgePurchaseParams) { billingResult ->
+                            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                                Log.d(TAG, "Purchase acknowledged successfully: ${purchase.products}")
+                            } else {
+                                Log.e(TAG, "Failed to acknowledge purchase: ${billingResult.responseCode} - ${billingResult.debugMessage}")
                             }
-                            shouldInvokeCallbackNow = false
-                        } else {
-                            Log.e(TAG, "BillingClient is not ready for acknowledgment")
+                            // Still grant benefit if state is PURCHASED, even if acknowledgment failed
+                            invokePurchaseCallback(true)
                         }
-                        
-                        if (shouldInvokeCallbackNow) {
-                            purchaseCallback?.invoke(true)
-                            purchaseCallback = null
-                        }
+                        shouldInvokeCallbackNow = false
                     } else {
-                        Log.d(TAG, "Purchase already acknowledged: ${purchase.products}")
-                        purchaseCallback?.invoke(true)
-                        purchaseCallback = null
+                        Log.e(TAG, "BillingClient is not ready for acknowledgment")
                     }
+                    
+                    if (shouldInvokeCallbackNow) {
+                        invokePurchaseCallback(true)
+                    }
+                } else {
+                    Log.d(TAG, "Purchase already acknowledged: ${purchase.products}")
+                    invokePurchaseCallback(true)
                 }
-                Purchase.PurchaseState.PENDING -> {
-                    Log.d(TAG, "Purchase is pending: ${purchase.products}")
-                    // Optionally notify user that purchase is pending
-                    // Don't invoke callback yet - wait for final state
-                }
-                else -> {
-                    Log.w(TAG, "Purchase state is unsuccessful (${purchase.purchaseState}): ${purchase.products}")
-                    purchaseCallback?.invoke(false)
-                    purchaseCallback = null
-                }
+            }
+            Purchase.PurchaseState.PENDING -> {
+                Log.d(TAG, "Purchase is pending: ${purchase.products}")
+                // Optionally notify user that purchase is pending
+                // Don't invoke callback yet - wait for final state
+            }
+            else -> {
+                Log.w(TAG, "Purchase state is unsuccessful (${purchase.purchaseState}): ${purchase.products}")
+                invokePurchaseCallback(false)
             }
         }
     }
@@ -330,7 +359,10 @@ class BillingHelper(private val context: Context) {
      */
     fun endConnection() {
         Log.d(TAG, "Ending billing client connection")
-        purchaseCallback = null
+        synchronized(callbackLock) {
+            purchaseCallback = null
+            purchasingProductId = null
+        }
         billingClient.endConnection()
     }
 

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/iap/BillingHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/iap/BillingHelper.kt
@@ -227,16 +227,19 @@ class BillingHelper(private val context: Context) {
 
                     purchaseCallback = callback
                     
+                    var launchSuccessful = false
                     if (billingClient.isReady) {
                         val launchResult = billingClient.launchBillingFlow(activity, billingParamsBuilder)
-
-                        if (launchResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                        if (launchResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                            launchSuccessful = true
+                        } else {
                             Log.e(TAG, "Failed to launch billing flow: ${launchResult.responseCode} - ${launchResult.debugMessage}")
-                            purchaseCallback = null
-                            callback(false)
                         }
                     } else {
                         Log.e(TAG, "BillingClient is not ready right before launching flow")
+                    }
+
+                    if (!launchSuccessful) {
                         purchaseCallback = null
                         callback(false)
                     }
@@ -260,21 +263,24 @@ class BillingHelper(private val context: Context) {
                             .setPurchaseToken(purchase.purchaseToken)
                             .build()
                         
+                        var shouldInvokeCallbackNow = true
                         if (billingClient.isReady) {
                             billingClient.acknowledgePurchase(acknowledgePurchaseParams) { billingResult ->
                                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                                     Log.d(TAG, "Purchase acknowledged successfully: ${purchase.products}")
-                                    purchaseCallback?.invoke(true)
-                                    purchaseCallback = null
                                 } else {
                                     Log.e(TAG, "Failed to acknowledge purchase: ${billingResult.responseCode} - ${billingResult.debugMessage}")
-                                    // Still grant benefit if state is PURCHASED, even if acknowledgment failed (might succeed later or via restore)
-                                    purchaseCallback?.invoke(true)
-                                    purchaseCallback = null
                                 }
+                                // Still grant benefit if state is PURCHASED, even if acknowledgment failed
+                                purchaseCallback?.invoke(true)
+                                purchaseCallback = null
                             }
+                            shouldInvokeCallbackNow = false
                         } else {
                             Log.e(TAG, "BillingClient is not ready for acknowledgment")
+                        }
+                        
+                        if (shouldInvokeCallbackNow) {
                             purchaseCallback?.invoke(true)
                             purchaseCallback = null
                         }

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
@@ -5,11 +5,8 @@ import com.kobby.hymnal.BuildKonfig
 import com.kobby.hymnal.core.config.RemoteConfigManager
 import com.kobby.hymnal.core.sharing.ShareConstants
 import android.util.Log
-import com.kobby.hymnal.BuildConfig
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import kotlinx.coroutines.tasks.await
 
 class AndroidUpdateManager(
@@ -17,27 +14,12 @@ class AndroidUpdateManager(
     private val remoteConfigManager: RemoteConfigManager
 ) : UpdateManager {
 
-    private val remoteConfig: FirebaseRemoteConfig by lazy {
-        FirebaseRemoteConfig.getInstance().apply {
-
-            val minFetchInterval = if (BuildConfig.DEBUG) 0L else  43200L // 12 hours
-            val configSettings = FirebaseRemoteConfigSettings.Builder()
-                .setMinimumFetchIntervalInSeconds(minFetchInterval)
-                .build()
-            setConfigSettingsAsync(configSettings)
-            // Default values
-            setDefaultsAsync(mapOf(
-                KEY_MIN_REQUIRED_VERSION to BuildKonfig.VERSION_NAME
-            ))
-        }
-    }
-
     override suspend fun checkForUpdates(): UpdateResult {
         val currentVersion = BuildKonfig.VERSION_NAME
 
         remoteConfigManager.fetchAndActivate()
 
-        val minRequiredVersion = remoteConfig.getString(KEY_MIN_REQUIRED_VERSION)
+        val minRequiredVersion = remoteConfigManager.getString(KEY_MIN_REQUIRED_VERSION, BuildKonfig.VERSION_NAME)
 
         val isMandatory = VersionUtils.isUpdateAvailable(currentVersion, minRequiredVersion)
         val playStoreUpdate = getPlayStoreUpdateInfo()

--- a/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/kobby/hymnal/core/update/AndroidUpdateManager.kt
@@ -8,9 +8,14 @@ import android.util.Log
 import com.kobby.hymnal.BuildConfig
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import kotlinx.coroutines.tasks.await
 
-class AndroidUpdateManager(private val context: Context) : UpdateManager {
+class AndroidUpdateManager(
+    private val context: Context,
+    private val remoteConfigManager: RemoteConfigManager
+) : UpdateManager {
 
     private val remoteConfig: FirebaseRemoteConfig by lazy {
         FirebaseRemoteConfig.getInstance().apply {

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/database/HymnRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/database/HymnRepository.kt
@@ -11,87 +11,87 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
-class HymnRepository(private val database: HymnDatabase) {
+open class HymnRepository(private val database: HymnDatabase) {
     
     // Hymn queries
-    fun getAllHymns(): Flow<List<Hymn>> {
+    open fun getAllHymns(): Flow<List<Hymn>> {
         return database.hymnsQueries.getAllHymns()
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    fun getHymnsByCategory(category: String): Flow<List<Hymn>> {
+    open fun getHymnsByCategory(category: String): Flow<List<Hymn>> {
         return database.hymnsQueries.getHymnsByCategory(category)
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    suspend fun getHymnById(id: Long): Hymn? = withContext(Dispatchers.Default) {
+    open suspend fun getHymnById(id: Long): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHymnById(id)
             .executeAsOneOrNull()
     }
     
-    suspend fun getHymnByNumber(number: Long, category: String): Hymn? = withContext(Dispatchers.Default) {
+    open suspend fun getHymnByNumber(number: Long, category: String): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHymnByNumber(number, category)
             .executeAsOneOrNull()
     }
     
-    suspend fun getRandomHymn(): Hymn? = withContext(Dispatchers.Default) {
+    open suspend fun getRandomHymn(): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getRandomHymn()
             .executeAsOneOrNull()
     }
     
-    fun searchHymns(query: String): Flow<List<Hymn>> {
+    open fun searchHymns(query: String): Flow<List<Hymn>> {
         return database.hymnsQueries.searchHymns(query)
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
     // Favorite queries
-    fun getFavoriteHymns(): Flow<List<Hymn>> {
+    open fun getFavoriteHymns(): Flow<List<Hymn>> {
         return database.hymnsQueries.getFavoriteHymns()
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    suspend fun addToFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
+    open suspend fun addToFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.addToFavorites(hymnId)
     }
     
-    suspend fun removeFromFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
+    open suspend fun removeFromFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.removeFromFavorites(hymnId)
     }
     
-    suspend fun isFavorite(hymnId: Long): Boolean = withContext(Dispatchers.Default) {
+    open suspend fun isFavorite(hymnId: Long): Boolean = withContext(Dispatchers.Default) {
         database.hymnsQueries.isFavorite(hymnId)
             .executeAsOne()
     }
     
     // History queries
-    fun getRecentHymns(limit: Long = 20) = database.hymnsQueries.getRecentHymns(limit)
+    open fun getRecentHymns(limit: Long = 20) = database.hymnsQueries.getRecentHymns(limit)
         .asFlow()
         .mapToList(Dispatchers.Default)
     
-    suspend fun addToHistory(hymnId: Long) = withContext(Dispatchers.Default) {
+    open suspend fun addToHistory(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.addToHistory(hymnId)
         trimHistoryToLimit()
     }
     
-    suspend fun clearHistory() = withContext(Dispatchers.Default) {
+    open suspend fun clearHistory() = withContext(Dispatchers.Default) {
         database.hymnsQueries.clearHistory()
     }
     
-    private suspend fun trimHistoryToLimit() = withContext(Dispatchers.Default) {
+    protected open suspend fun trimHistoryToLimit() = withContext(Dispatchers.Default) {
         database.hymnsQueries.trimHistoryToLimit(HISTORY_LIMIT)
     }
     
     // Highlight queries
-    suspend fun getHighlightsForHymn(hymnId: Long) = withContext(Dispatchers.Default) {
+    open suspend fun getHighlightsForHymn(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHighlightsForHymn(hymnId)
             .executeAsList()
     }
     
-    fun getHymnsWithHighlights(): Flow<List<Hymn>> {
+    open fun getHymnsWithHighlights(): Flow<List<Hymn>> {
         return database.hymnsQueries.getHymnsWithHighlights()
             .asFlow()
             .mapToList(Dispatchers.Default)

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/database/HymnRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/database/HymnRepository.kt
@@ -11,87 +11,87 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
-open class HymnRepository(private val database: HymnDatabase) {
+class HymnRepository(private val database: HymnDatabase) {
     
     // Hymn queries
-    open fun getAllHymns(): Flow<List<Hymn>> {
+    fun getAllHymns(): Flow<List<Hymn>> {
         return database.hymnsQueries.getAllHymns()
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    open fun getHymnsByCategory(category: String): Flow<List<Hymn>> {
+    fun getHymnsByCategory(category: String): Flow<List<Hymn>> {
         return database.hymnsQueries.getHymnsByCategory(category)
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    open suspend fun getHymnById(id: Long): Hymn? = withContext(Dispatchers.Default) {
+    suspend fun getHymnById(id: Long): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHymnById(id)
             .executeAsOneOrNull()
     }
     
-    open suspend fun getHymnByNumber(number: Long, category: String): Hymn? = withContext(Dispatchers.Default) {
+    suspend fun getHymnByNumber(number: Long, category: String): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHymnByNumber(number, category)
             .executeAsOneOrNull()
     }
     
-    open suspend fun getRandomHymn(): Hymn? = withContext(Dispatchers.Default) {
+    suspend fun getRandomHymn(): Hymn? = withContext(Dispatchers.Default) {
         database.hymnsQueries.getRandomHymn()
             .executeAsOneOrNull()
     }
     
-    open fun searchHymns(query: String): Flow<List<Hymn>> {
+    fun searchHymns(query: String): Flow<List<Hymn>> {
         return database.hymnsQueries.searchHymns(query)
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
     // Favorite queries
-    open fun getFavoriteHymns(): Flow<List<Hymn>> {
+    fun getFavoriteHymns(): Flow<List<Hymn>> {
         return database.hymnsQueries.getFavoriteHymns()
             .asFlow()
             .mapToList(Dispatchers.Default)
     }
     
-    open suspend fun addToFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
+    suspend fun addToFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.addToFavorites(hymnId)
     }
     
-    open suspend fun removeFromFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
+    suspend fun removeFromFavorites(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.removeFromFavorites(hymnId)
     }
     
-    open suspend fun isFavorite(hymnId: Long): Boolean = withContext(Dispatchers.Default) {
+    suspend fun isFavorite(hymnId: Long): Boolean = withContext(Dispatchers.Default) {
         database.hymnsQueries.isFavorite(hymnId)
             .executeAsOne()
     }
     
     // History queries
-    open fun getRecentHymns(limit: Long = 20) = database.hymnsQueries.getRecentHymns(limit)
+    fun getRecentHymns(limit: Long = 20) = database.hymnsQueries.getRecentHymns(limit)
         .asFlow()
         .mapToList(Dispatchers.Default)
     
-    open suspend fun addToHistory(hymnId: Long) = withContext(Dispatchers.Default) {
+    suspend fun addToHistory(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.addToHistory(hymnId)
         trimHistoryToLimit()
     }
     
-    open suspend fun clearHistory() = withContext(Dispatchers.Default) {
+    suspend fun clearHistory() = withContext(Dispatchers.Default) {
         database.hymnsQueries.clearHistory()
     }
     
-    protected open suspend fun trimHistoryToLimit() = withContext(Dispatchers.Default) {
+    private suspend fun trimHistoryToLimit() = withContext(Dispatchers.Default) {
         database.hymnsQueries.trimHistoryToLimit(HISTORY_LIMIT)
     }
     
     // Highlight queries
-    open suspend fun getHighlightsForHymn(hymnId: Long) = withContext(Dispatchers.Default) {
+    suspend fun getHighlightsForHymn(hymnId: Long) = withContext(Dispatchers.Default) {
         database.hymnsQueries.getHighlightsForHymn(hymnId)
             .executeAsList()
     }
     
-    open fun getHymnsWithHighlights(): Flow<List<Hymn>> {
+    fun getHymnsWithHighlights(): Flow<List<Hymn>> {
         return database.hymnsQueries.getHymnsWithHighlights()
             .asFlow()
             .mapToList(Dispatchers.Default)

--- a/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/kobby/hymnal/core/iap/PurchaseStorage.kt
@@ -65,7 +65,11 @@ class PurchaseStorage(private val settings: Settings) {
      * Get or set the product ID of the active purchase.
      */
     var productId: String?
-        get() = settings.getString(KEY_PRODUCT_ID, "")
+
+        get() {
+            val id = settings.getString(KEY_PRODUCT_ID, "")
+            return if (id.isEmpty()) null else id
+        }
         set(value) {
             if (value != null) {
                 settings.putString(KEY_PRODUCT_ID, value)

--- a/composeApp/src/commonTest/kotlin/com/kobby/hymnal/core/database/SafeHymnRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/kobby/hymnal/core/database/SafeHymnRepositoryTest.kt
@@ -1,10 +1,11 @@
 package com.kobby.hymnal.core.database
 
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.kobby.hymnal.composeApp.database.HymnDatabase
 import com.kobby.hymnal.composeApp.database.Hymn
 import com.kobby.hymnal.core.crashlytics.CrashlyticsManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -50,58 +51,48 @@ class SafeHymnRepositoryTest {
         }
     }
     
-    // Test double that mimics HymnRepository behavior without requiring actual database
-    // Note: This is a simplified test implementation. In production code, consider using:
-    // - A proper in-memory test database
-    // - A mocking framework like MockK for better type safety
-    // - Extracting an interface for easier testing
-    private class TestHymnRepository(
-        private val shouldThrow: Boolean = false,
-        @Suppress("UNUSED_PARAMETER") database: Any? = null
-    ) : HymnRepository(
-        // Workaround: Cast to HymnDatabase for testing purposes
-        // The methods are overridden, so the database is never actually used
-        @Suppress("UNCHECKED_CAST")
-        (object : Any() {} as com.kobby.hymnal.composeApp.database.HymnDatabase)
-    ) {
+    private fun createRepository(shouldThrow: Boolean = false): Pair<HymnRepository, JdbcSqliteDriver> {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        HymnDatabase.Schema.create(driver)
+        val database = HymnDatabase(driver)
         
-        override fun getAllHymns(): Flow<List<Hymn>> {
-            if (shouldThrow) throw RuntimeException("Test error")
-            return flowOf(emptyList())
-        }
+        // Insert a test hymn so there's always at least one valid hymn for queries
+        database.hymnsQueries.insertHymn(
+            number = 1,
+            title = "Amazing Grace",
+            category = "ancient_modern",
+            content = "Amazing grace, how sweet the sound"
+        )
         
-        override suspend fun getHymnById(id: Long): Hymn? {
-            if (shouldThrow) throw RuntimeException("Test error")
-            return null
+        val repository = HymnRepository(database)
+        if (shouldThrow) {
+            driver.close()
         }
-        
-        override suspend fun addToFavorites(hymnId: Long) {
-            if (shouldThrow) throw RuntimeException("Test error")
-        }
-        
-        override fun searchHymns(query: String): Flow<List<Hymn>> {
-            if (shouldThrow) throw RuntimeException("Test error")
-            return flowOf(emptyList())
-        }
+        return Pair(repository, driver)
     }
     
     @Test
     fun testGetHymnByIdSuccess() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = false)
-        val safeRepository = SafeHymnRepository(repository, crashlytics)
-        
-        val result = safeRepository.getHymnById(1L)
-        
-        assertNull(result)
-        assertEquals(0, crashlytics.exceptions.size)
-        assertEquals(0, crashlytics.logs.size)
+        val (repository, driver) = createRepository(shouldThrow = false)
+        try {
+            val safeRepository = SafeHymnRepository(repository, crashlytics)
+            
+            val result = safeRepository.getHymnById(1L)
+            
+            assertNotNull(result)
+            assertEquals(1L, result.id)
+            assertEquals(0, crashlytics.exceptions.size)
+            assertEquals(0, crashlytics.logs.size)
+        } finally {
+            driver.close()
+        }
     }
     
     @Test
     fun testGetHymnByIdFailure() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = true)
+        val (repository, driver) = createRepository(shouldThrow = true)
         val safeRepository = SafeHymnRepository(repository, crashlytics)
         
         val result = safeRepository.getHymnById(123L)
@@ -110,47 +101,51 @@ class SafeHymnRepositoryTest {
         assertEquals(1, crashlytics.exceptions.size)
         assertEquals(1, crashlytics.logs.size)
         assertEquals("Error in getHymnById: 123", crashlytics.logs[0])
-        assertEquals(123, crashlytics.customKeys["hymn_id"])
+        assertEquals("123", crashlytics.customKeys["hymn_id"])
     }
     
     @Test
     fun testAddToFavoritesSuccess() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = false)
-        val safeRepository = SafeHymnRepository(repository, crashlytics)
-        
-        safeRepository.addToFavorites(1L)
-        
-        assertEquals(0, crashlytics.exceptions.size)
+        val (repository, driver) = createRepository(shouldThrow = false)
+        try {
+            val safeRepository = SafeHymnRepository(repository, crashlytics)
+            
+            safeRepository.addToFavorites(1L)
+            
+            assertEquals(0, crashlytics.exceptions.size)
+        } finally {
+            driver.close()
+        }
     }
     
     @Test
     fun testAddToFavoritesFailure() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = true)
+        val (repository, driver) = createRepository(shouldThrow = true)
         val safeRepository = SafeHymnRepository(repository, crashlytics)
         
         try {
             safeRepository.addToFavorites(456L)
-        } catch (e: RuntimeException) {
+        } catch (e: Exception) {
             // Expected to throw after logging
         }
         
         assertEquals(1, crashlytics.exceptions.size)
         assertEquals(1, crashlytics.logs.size)
         assertEquals("Error in addToFavorites: 456", crashlytics.logs[0])
-        assertEquals(456, crashlytics.customKeys["hymn_id"])
+        assertEquals("456", crashlytics.customKeys["hymn_id"])
     }
     
     @Test
     fun testSearchHymnsReportsExceptionOnError() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = true)
+        val (repository, driver) = createRepository(shouldThrow = true)
         val safeRepository = SafeHymnRepository(repository, crashlytics)
         
         try {
             safeRepository.searchHymns("test query").first()
-        } catch (e: RuntimeException) {
+        } catch (e: Exception) {
             // Expected - exception is logged and re-thrown
         }
         
@@ -162,19 +157,23 @@ class SafeHymnRepositoryTest {
     @Test
     fun testGetAllHymnsSuccess() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = false)
-        val safeRepository = SafeHymnRepository(repository, crashlytics)
-        
-        val result = safeRepository.getAllHymns().first()
-        
-        assertEquals(emptyList(), result)
-        assertEquals(0, crashlytics.exceptions.size)
+        val (repository, driver) = createRepository(shouldThrow = false)
+        try {
+            val safeRepository = SafeHymnRepository(repository, crashlytics)
+            
+            val result = safeRepository.getAllHymns().first()
+            
+            assertEquals(1, result.size)
+            assertEquals(0, crashlytics.exceptions.size)
+        } finally {
+            driver.close()
+        }
     }
     
     @Test
     fun testMultipleOperationsRecordsSeparateExceptions() = runTest {
         val crashlytics = TestCrashlyticsManager()
-        val repository = TestHymnRepository(shouldThrow = true)
+        val (repository, driver) = createRepository(shouldThrow = true)
         val safeRepository = SafeHymnRepository(repository, crashlytics)
         
         // First operation
@@ -188,6 +187,6 @@ class SafeHymnRepositoryTest {
         assertEquals(2, crashlytics.exceptions.size)
         
         // Verify custom keys were set for both
-        assertEquals(2, crashlytics.customKeys["hymn_id"]) // Last value
+        assertEquals("2", crashlytics.customKeys["hymn_id"]) // Last value
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/kobby/hymnal/core/iap/SubscriptionStorageTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/kobby/hymnal/core/iap/SubscriptionStorageTest.kt
@@ -94,7 +94,7 @@ class SubscriptionStorageTest {
     }
 
     @Test
-    fun `hasAccess is false for no purchase`() = runTest {
+    fun `hasAccess is true for no purchase`() = runTest {
         // Given
         val storage = createTestStorage()
 
@@ -102,7 +102,8 @@ class SubscriptionStorageTest {
         val info = storage.getEntitlementInfo()
         
         // Then
-        assertFalse(info.hasAccess)
+        // In the new model, everyone has access because features are free
+        assertTrue(info.hasAccess)
     }
 
     @Test


### PR DESCRIPTION
Enhance the Android billing flow with safer launch checks and guaranteed callback invocation to prevent NPEs and UI hangs when the BillingClient state changes unexpectedly.

Refactor the HymnRepository to be open for mocking and restore the SQLDelight JVM driver to common tests. These changes improve the overall testability of the data layer.

Update the IAP storage logic and associated tests to support the transition to a free-access model. Inject RemoteConfigManager into the update manager to enable remote control over update prompts.